### PR TITLE
Update to incorporate power_state 

### DIFF
--- a/custom_components/jvcprojector/README.md
+++ b/custom_components/jvcprojector/README.md
@@ -16,11 +16,14 @@ remote:
   - platform: jvcprojector
     name: Projector
     host: 192.168.1.14
+    scan_interval: 30
 ```
 ### Configuration Variables
 **name:** (string) (Required) friendly name for your projector.
 
 **host:** (string) (Required) your projector IP address.
+
+**host:** (string) (Optional) timeout used to update the component (strong suggestion to set this to 30 or higher)
 
 ### Service `remote.turn_off`
 | Service data attribute | Optional | Description |

--- a/custom_components/jvcprojector/README.md
+++ b/custom_components/jvcprojector/README.md
@@ -23,7 +23,7 @@ remote:
 
 **host:** (string) (Required) your projector IP address.
 
-**host:** (string) (Optional) timeout used to update the component (strong suggestion to set this to 30 or higher)
+**scan_interval:** (string) (Optional) timeout used to update the component (strong suggestion to set this to 30 or higher)
 
 ### Service `remote.turn_off`
 | Service data attribute | Optional | Description |

--- a/custom_components/jvcprojector/remote.py
+++ b/custom_components/jvcprojector/remote.py
@@ -81,7 +81,12 @@ class JVCRemote(remote.RemoteDevice):
 
         for com in command:
             _LOGGER.info(f"sending command: {com}")
-            command_sent = self._jvc.command(com)
+            try:
+                command_sent = self._jvc.command(com)
+            except Exception:
+                # when an error occured during sending, command execution probably failed
+                command_sent = False
+
             if not command_sent:
                 self._last_command_sent = "N/A"
                 continue
@@ -89,4 +94,9 @@ class JVCRemote(remote.RemoteDevice):
                 self._last_command_sent = com
 
     async def async_update_state(self):
-        self._power_state = self._jvc.power_state()
+        """"Update the state with the Power Status (if available)"""
+
+        try:
+            self._power_state = self._jvc.power_state()
+        except Exception:
+            self._power_state = 'unknown'

--- a/custom_components/jvcprojector/remote.py
+++ b/custom_components/jvcprojector/remote.py
@@ -63,9 +63,9 @@ class JVCRemote(remote.RemoteDevice):
             'power_state': self._power_state,
         }
 
-    def turn_on(self, **kwargs):
+    async def turn_on(self, **kwargs):
         """Turn the remote on."""
-        self.async_send_command('power_off')
+        await self.async_send_command('power_on')
         self._state = True
 
     async def async_turn_off(self, **kwargs):

--- a/custom_components/jvcprojector/remote.py
+++ b/custom_components/jvcprojector/remote.py
@@ -52,7 +52,10 @@ class JVCRemote(remote.RemoteDevice):
     def device_state_attributes(self):
         """Return device state attributes."""
         if self._last_command_sent is not None:
-            return {'last_command_sent': self._last_command_sent}
+            return {
+                'last_command_sent': self._last_command_sent,
+                'power_state': 'testing',
+            }
 
     async def async_turn_on(self, **kwargs):
         """Turn the remote on."""


### PR DESCRIPTION
This incorporates the use of the PowerState in jvc_projector, and staged in pull request: https://github.com/bezmi/jvc_projector/pull/5

It should be fully backwards compatbile (ie: if integrations depend on it, it should still work as the base state is still on/off).
Because the dependency on jvc_projector and its pull-request I could not test it in ideal situations. I did however test it by depending on my local jvc_remote project.

When accepting this, an update should be done to the manifest.json (i guess it will be 0.0.3)