### PR TITLE
Modify JVCRemote to extend RemoteEntity

### DIFF
--- a/custom_components/jvcprojector/manifest.json
+++ b/custom_components/jvcprojector/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "jvcprojector",
   "name": "JVC Projector IP Control",
-  "documentation": "https://github.com/alterbridge86/hass_custom_components",
+  "documentation": "https://github.com/bezmi/hass_custom_components",
   "requirements": ["jvc-projector-remote == 0.0.2"],
   "dependencies": [],
   "codeowners": [

--- a/custom_components/jvcprojector/manifest.json
+++ b/custom_components/jvcprojector/manifest.json
@@ -1,10 +1,12 @@
 {
   "domain": "jvcprojector",
   "name": "JVC Projector IP Control",
-  "documentation": "https://github.com/bezmi/hass_custom_components",
+  "documentation": "https://github.com/alterbridge86/hass_custom_components",
   "requirements": ["jvc-projector-remote == 0.0.2"],
   "dependencies": [],
   "codeowners": [
-    "@bezmi"
-  ]
+    "@bezmi",
+    "@alterbridge86"
+  ],
+  "version": "0.0.2"
 }

--- a/custom_components/jvcprojector/remote.py
+++ b/custom_components/jvcprojector/remote.py
@@ -17,7 +17,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     ])
 
 
-class JVCRemote(remote.RemoteDevice):
+class JVCRemote(remote.RemoteEntity):
     """Home assistant JVC remote representation"""
 
     def __init__(self, name, host):


### PR DESCRIPTION
Simple change here to modify JVCRemote class to extend RemoteEntity instead of RemoteDevice. No change in functionality, just following upstream class naming changes in 0.109 to avoid receiving the warning in the log.