### PR TITLE
Add a version to manifest.json

### DIFF
--- a/custom_components/jvcprojector/manifest.json
+++ b/custom_components/jvcprojector/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": [],
   "codeowners": [
     "@bezmi"
-  ]
+  ],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Adds a version to `custom_components/jvcprojector/manifest.json`

Upon restart, I see this in HA logs:

```
WARNING: No 'version' key in the manifest file for custom integration 'jvcprojector'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'jvcprojector'
```

Home Assistant manifest documentation: https://developers.home-assistant.io/docs/creating_integration_manifest/#version